### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ notifications:
 
     rooms:
       - biostandards:sWYxFbqTh8MdyTeZkC7ZisgN#travis-ci
+      - enterprisegenomics:Z5VoMKtrbyGNdWXW9Ovf06d4#travis-ci
     
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: python
 branches:
   only:
     - master
-    - TravisCI
+    - Travis
+    - develop
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,8 @@ install:
 # command to run tests
 script: python  examples/ex1.py 
 
-
+notifications:
+  email:
+    recipients:
+      - yassinesouilmi@gmail.com
+      - egafni@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,14 @@ notifications:
     recipients:
       - yassinesouilmi@gmail.com
       - egafni@gmail.com
+
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/d633832f63a4e7c2ad7f
+
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always
+
+  slack: biostandards:sWYxFbqTh8MdyTeZkC7ZisgN
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ notifications:
       - yassinesouilmi@gmail.com
       - egafni@gmail.com
 
+  # Gitter notifications
   webhooks:
     urls:
+      - https://webhooks.gitter.im/e/69b116e4116196985f1b
       - https://webhooks.gitter.im/e/d633832f63a4e7c2ad7f
 
     on_success: always  # options: [always|never|change] default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,15 @@ notifications:
     urls:
       - https://webhooks.gitter.im/e/d633832f63a4e7c2ad7f
 
-    on_success: change  # options: [always|never|change] default: always
+    on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-  slack: biostandards:sWYxFbqTh8MdyTeZkC7ZisgN
+  slack: 
 
+    rooms:
+      - biostandards:sWYxFbqTh8MdyTeZkC7ZisgN#travis-ci
+    
+    on_success: always  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+
+# whitelist
+branches:
+  only:
+    - master
+    - TravisCI
+
+python:
+  - "2.7"
+
+# Befor installation
+before_install:
+
+  - sudo apt-get update -qq
+
+# command to install dependencies
+install:
+  - pip install .
+
+# command to run tests
+script: python  examples/ex1.py 
+
+

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,11 @@
+.. image:: https://travis-ci.org/yassineS/COSMOS-2.0.svg?branch=master
+    :target: https://travis-ci.org/yassineS/COSMOS-2.0
+
+.. image:: https://badges.gitter.im/Join%20Chat.svg
+   :alt: Join the chat at https://gitter.im/LPM-HMS/Cosmos2
+   :target: https://gitter.im/LPM-HMS/Cosmos2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+
+
 COSMOS is currently BETA.  Although the code is considered stable,
 we are planning a major publication before the official release.
 
@@ -5,11 +13,9 @@ we are planning a major publication before the official release.
 For more information and the full documentation please visit
 `http://lpm-hms.github.io/COSMOS-2.0/ <http://lpm-hms.github.io/COSMOS-2.0/>`_. 
 
-To chat with the author/other users (many of which use COSMOS to make bioinformatics NGS workflows), use gitter:
+To chat with the author/other users (many of which use COSMOS to make bioinformatics NGS workflows), join the chat on gitter at:
 
-.. image:: https://badges.gitter.im/Join%20Chat.svg
-   :alt: Join the chat at https://gitter.im/LPM-HMS/Cosmos2
-   :target: https://gitter.im/LPM-HMS/Cosmos2?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+`https://gitter.im/LPM-HMS/Cosmos2/ <https://gitter.im/LPM-HMS/Cosmos2/>`_.
 
 Install
 ==========


### PR DESCRIPTION
Switching the pull request to the develop branch instead of master.

- All python commands on Travis according to the documentation are ran in a virtualenv. It is also possible to add any pip install command to the process, either before the build of the github code or after, I don't know how they will play together, but I can give it a shot. However, this will not generate a separate message.
- Done here
- After each build on Travis I receive an email (whether success or failure). However, there is no option to alert multiple emails at once. One workaround is to add an email/text notification option to ex1.py.
- It is possible to run on all the branches, also it is possible to specify which branches to include or exclude (note the include in the yml file). For the time being I am setting up travis to monitor only the master and TravisCI branches. However, the build will not run if there is no yml file in the branch. I'll edit it to include the develop branch now.