### PR TITLE
Changes to hackathon branch to help with ruffus->cosmos migration.

### DIFF
--- a/cosmos/job/drm/drm_drmaa.py
+++ b/cosmos/job/drm/drm_drmaa.py
@@ -54,6 +54,7 @@ class DRM_DRMAA(DRM):
                 extra_jobinfo['successful'] = extra_jobinfo is not None and \
                     int(extra_jobinfo['exitStatus']) == 0 and \
                     extra_jobinfo['wasAborted'] == False and \
+                    extra_jobinfo['hasSignaled'] == False and \
                     extra_jobinfo['hasExited']
                 yield jobid_to_task.pop(int(extra_jobinfo['jobId'])), parse_extra_jobinfo(extra_jobinfo)
 

--- a/cosmos/job/drm/drm_local.py
+++ b/cosmos/job/drm/drm_local.py
@@ -20,9 +20,7 @@ class DRM_Local(DRM):
         p = psutil.Popen(task.output_command_script_path,
                          stdout=open(task.output_stderr_path, 'w'),
                          stderr=open(task.output_stdout_path, 'w'),
-                         preexec_fn=preexec_function(),
-                         shell=False, env=os.environ
-                         )
+                         shell=False, env=os.environ)
         p.start_time = time.time()
         drm_jobID = p.pid
         self.procs[drm_jobID] = p
@@ -77,13 +75,6 @@ class DRM_Local(DRM):
     def kill_tasks(self, tasks):
         for t in tasks:
             self.kill(t)
-
-
-def preexec_function():
-    # Ignore the SIGINT signal by setting the handler to the standard
-    # signal handler SIG_IGN.  This allows Cosmos to cleanly
-    # terminate jobs when there is a ctrl+c event
-    os.setpgrp()
 
 
 class JobStatusError(Exception):

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -121,9 +121,9 @@ class Workflow(Base):
 
     def make_output_dirs(self):
         dirs = {os.path.dirname(p) for t in self.tasks for p in t.output_map.values()}
-        for dir in dirs:
-            if dir != '':
-                sp.check_call(['mkdir', '-p', dir])
+        for d in dirs:
+            if d != '':
+                sp.check_call(['mkdir', '-p', os.path.join(self.output_dir, d)])
 
     def add_task(self, func, params=None, parents=None, uid=None, stage_name=None, drm=None):
         """


### PR DESCRIPTION
478506e removes code that can prevent jenkins from launching Cosmos in rare cases.
b02246c catches an obscure error that can occur when a job is submitted, and logs the offending job.
3a91ced, 52cb9e4 and 9b9e7c0 make Cosmos more resilient to some of the unusual exceptions that drmaa can throw when a job is killed by `qdel` or a `commlib error`, and prevent Cosmos from thinking a Task that was killed by a cluster admin completed successfully.
0e5af4e places relative paths correctly and prevents `Workflow.make_output_dirs()` from breaking PIPE's test harness.