### PR TITLE
Hackathon patches, round 2

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -1,10 +1,11 @@
 import os
-from collections import namedtuple
-
-# turn SQLAlchemy warnings into errors
+import types
 import warnings
+
+from collections import namedtuple
 from sqlalchemy.exc import SAWarning
 
+# turn SQLAlchemy warnings into errors
 warnings.simplefilter("error", SAWarning)
 
 opj = os.path.join
@@ -28,7 +29,7 @@ def recursive_resolve_dependency(parameter):
     """
     if isinstance(parameter, Dependency):
         return parameter.resolve(), {parameter.task}
-    elif type(parameter) in (str, unicode, int, float, long, bool):
+    elif type(parameter) in (bool, float, int, long, str, unicode, types.NoneType):
         return parameter, set()
     elif type(parameter) == list:
         tuple_list = list(recursive_resolve_dependency(v) for v in parameter)

--- a/cosmos/job/drm/drm_drmaa.py
+++ b/cosmos/job/drm/drm_drmaa.py
@@ -174,10 +174,10 @@ def parse_drmaa_jobinfo(drmaa_jobinfo):
         system_time=float(d.get('ru_stime', 0)),
 
         # TODO should we be calling convert_size_to_kb() for avg_rss_mem?
-        avg_rss_mem=d.get('ru_ixrss', 0),
-        max_rss_mem_kb=convert_size_to_kb(d.get('ru_maxrss', 0)),
+        avg_rss_mem=d.get('ru_ixrss', "0"),
+        max_rss_mem_kb=convert_size_to_kb(d.get('ru_maxrss', "0")),
         avg_vms_mem_kb=None,
-        max_vms_mem_kb=convert_size_to_kb(d.get('maxvmem', 0)),
+        max_vms_mem_kb=convert_size_to_kb(d.get('maxvmem', "0")),
 
         io_read_count=int(float(d.get('ru_inblock', 0))),
         io_write_count=int(float(d.get('ru_oublock', 0))),

--- a/cosmos/job/drm/drm_drmaa.py
+++ b/cosmos/job/drm/drm_drmaa.py
@@ -131,7 +131,10 @@ class DRM_DRMAA(DRM):
         import drmaa
 
         if task.drm_jobID is not None:
-            get_drmaa_session().control(str(task.drm_jobID), drmaa.JobControlAction.TERMINATE)
+            try:
+                get_drmaa_session().control(str(task.drm_jobID), drmaa.JobControlAction.TERMINATE)
+            except drmaa.errors.InvalidJobException:
+                pass
 
     def kill_tasks(self, tasks):
         for t in tasks:

--- a/cosmos/job/drm/drm_drmaa.py
+++ b/cosmos/job/drm/drm_drmaa.py
@@ -101,17 +101,16 @@ class DRM_DRMAA(DRM):
                     try:
                         drmaa_jobstatus = get_drmaa_session().jobStatus(str(jobid))
                     except drmaa.errors.InvalidJobException:
-                        drmaa_jobstatus = drmaa.JobState.FAILED
+                        drmaa_jobstatus = drmaa.JobState.UNDETERMINED
                     except Exception:
                         drmaa_jobstatus = drmaa.JobState.UNDETERMINED
 
-                    if drmaa_jobstatus in (drmaa.JobState.DONE,
-                                           drmaa.JobState.FAILED,
-                                           drmaa.JobState.UNDETERMINED):
+                    if drmaa_jobstatus == drmaa.JobState.UNDETERMINED:
                         cosmos_jobinfo = create_empty_drmaa_jobinfo(os.EX_TEMPFAIL)
                         failed_jobs.append((jobid_to_task.pop(jobid), cosmos_jobinfo))
 
             for jobid, task in failed_jobs:
+                print >>sys.stderr, 'job %d is missing and presumed dead' % jobid
                 yield jobid, task
 
     def drm_statuses(self, tasks):

--- a/cosmos/util/helpers.py
+++ b/cosmos/util/helpers.py
@@ -186,7 +186,8 @@ def get_logger(name, path):
     # create file handler which logs debug messages
     if path:
         d = os.path.dirname(path)
-        assert d == '' or os.path.exists(d), 'Cannot write to %s' % path
+        assert d == '' or os.path.exists(d), \
+            'Cannot write to %s from %s' % (path, os.getcwd())
         fh = logging.FileHandler(path)
         fh.setLevel(logging.DEBUG)
         fh.setFormatter(logging.Formatter('%(levelname)s: %(asctime)s: %(message)s', "%Y-%m-%d %H:%M:%S"))


### PR DESCRIPTION
Various changes to help with the `output_dir` deprecation and make Cosmos more resilient to drmaa errors.

4598a89 adds `os.getcwd()` to exception text if a log file can't be created (to help pin down remaining `output_dir` nits in client code.
c86deab restores the ability to pass a `None` argument to a Task's `params`.
d98127c silences secondary exceptions when tearing down running Tasks during a Cosmos crash.
1306369, 7549ef7 defend against degenerate drmaa responses when a Task is submitted to SGE with invalid options.
52c8170 should prevent completed jobs from being flagged as failed if the dreaded `commlib` monster rears its ugly head again.