### PR TITLE
Changes to logging and CLI arguments

### DIFF
--- a/cosmos/job/drm/drm_drmaa.py
+++ b/cosmos/job/drm/drm_drmaa.py
@@ -104,7 +104,7 @@ class DRM_DRMAA(DRM):
                         drmaa_jobstatus = drmaa.JobState.UNDETERMINED
 
                     if drmaa_jobstatus == drmaa.JobState.UNDETERMINED:
-                        print >>sys.stderr, 'job %d is missing and presumed dead' % jobid
+                        print >>sys.stderr, 'job %s is missing and presumed dead' % jobid
                         yield jobid_to_task.pop(jobid), \
                               create_empty_drmaa_jobinfo(os.EX_TEMPFAIL)
 

--- a/cosmos/util/args.py
+++ b/cosmos/util/args.py
@@ -9,11 +9,11 @@ def get_last_cmd_executed():
 #
 def add_workflow_args(p, require_name=True):
     p.add_argument('--name', '-n', help="A name for this workflow", required=require_name)
-    p.add_argument('--max_cores', '-c', type=int,
+    p.add_argument('--max_cores', '--max-cores', '-c', type=int,
                    help="Maximum number (based on the sum of cpu_requirement) of cores to use at once.  0 means unlimited", default=None)
-    p.add_argument('--max_attempts', '-a', type=int,
+    p.add_argument('--max_attempts', '--max-attempts', '-a', type=int,
                    help="Maximum number of times to try running a Task that must succeed before the workflow fails", default=1)
     p.add_argument('--restart', '-r', action='store_true',
                    help="Completely restart the workflow.  Note this will delete all record of the workflow in the database")
-    p.add_argument('--skip_confirm', '-y', action='store_true',
+    p.add_argument('--skip_confirm', '--skip-confirm', '-y', action='store_true',
                    help="Do not use confirmation prompts before restarting or deleting, and assume answer is always yes")

--- a/cosmos/util/args.py
+++ b/cosmos/util/args.py
@@ -7,11 +7,8 @@ def get_last_cmd_executed():
     return ' '.join([os.path.basename(sys.argv[0])] + cmd_args)
 
 #
-def add_workflow_args(parser):
-    p = parser
-    # parser.add_argument('-o', '--output_dir', type=str, help="The directory to output files to.  Path should not exist if this is a new workflow.")
-
-    p.add_argument('--name', '-n', help="A name for this workflow", required=True)
+def add_workflow_args(p, require_name=True):
+    p.add_argument('--name', '-n', help="A name for this workflow", required=require_name)
     p.add_argument('--max_cores', '-c', type=int,
                    help="Maximum number (based on the sum of cpu_requirement) of cores to use at once.  0 means unlimited", default=None)
     p.add_argument('--max_attempts', '-a', type=int,
@@ -20,5 +17,3 @@ def add_workflow_args(parser):
                    help="Completely restart the workflow.  Note this will delete all record of the workflow in the database")
     p.add_argument('--skip_confirm', '-y', action='store_true',
                    help="Do not use confirmation prompts before restarting or deleting, and assume answer is always yes")
-
-


### PR DESCRIPTION
This round of changes fixes a typo in a log message that will cause Cosmos to crash when trying to recover from a drmaa exception. Embarrassing!
It also includes changes to `add_workflow_args()` to make things easier for PIPE scripts.