### PR TITLE
Log raw qacct data and exit status when a task fails.

### DIFF
--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -90,7 +90,6 @@ class DRM_GE(DRM):
             max_num_fds=None,
 
             memory=float(d['mem']),
-
         )
 
     def kill(self, task):
@@ -157,6 +156,9 @@ def qacct(task, timeout=600):
 
         qacct_dict[k] = v.strip()
 
+    if is_garbage(qacct_dict) or qacct_dict['failed'][0] != '0':
+        task.workflow.log.warn('`qacct -j %s` (for task %s) shows job failure:\n%s' %
+                               (task.drm_jobID, task, qacct_out))
     return qacct_dict
 
 

--- a/cosmos/models/Task.py
+++ b/cosmos/models/Task.py
@@ -32,6 +32,7 @@ class GetOutputError(Exception): pass
 
 
 task_failed_printout = u"""Failure Info:
+<EXIT_STATUS="{0.exit_status}">
 <COMMAND path="{0.output_command_script_path}" drm_jobID="{0.drm_jobID}"
 params="{0.params_pretty}">
 


### PR DESCRIPTION
I haven't been able to reproduce the transient qacct errors we've been seeing these last few days. This PR will dump qacct's output to the log file. (I have a hunch that during these error states qacct is producing different output than it does when we go back and check after the fact.)