### PR TITLE
defend against Error 26 condition that kills jobs before they are scheduled [do not merge]

### DIFF
--- a/cosmos/api.py
+++ b/cosmos/api.py
@@ -15,6 +15,7 @@ from cosmos.graph.draw import draw_task_graph, draw_stage_graph, pygraphviz_avai
 import funcsigs
 import re
 
+from black_magic.decorator import partial
 from decorator import decorator
 
 

--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -149,6 +149,10 @@ class DRM_GE(DRM):
             memory=float(d['mem']),
         )
 
+        # check if the job failed before being scheduled
+        if processed_data['wall_time'] == 0.0 and processed_data['exit_status'] == 26:
+            processed_data['scheduling_error'] = True
+
         return processed_data, data_are_suspicious
 
     def kill(self, task):

--- a/cosmos/models/Cosmos.py
+++ b/cosmos/models/Cosmos.py
@@ -197,6 +197,7 @@ class Cosmos(object):
             #     assert not os.path.exists(output_dir), 'Workflow.output_dir `%s` already exists.' % (output_dir)
 
             wf = Workflow(id=old_id, name=name, primary_log_path=primary_log_path, manual_instantiation=False, successful=False)
+            wf.status = WorkflowStatus.no_attempt
             # mkdir(output_dir)  # make it here so we can start logging to logfile
             session.add(wf)
 

--- a/cosmos/models/Task.py
+++ b/cosmos/models/Task.py
@@ -1,18 +1,15 @@
 import os
-import itertools as it
-import shutil
 import codecs
 import networkx as nx
 import subprocess as sp
-from sqlalchemy.orm import relationship, synonym, backref
+from sqlalchemy.orm import relationship, synonym
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.schema import Column, ForeignKey, UniqueConstraint
-from sqlalchemy.types import Boolean, Integer, String, DateTime, BigInteger
+from sqlalchemy.types import Boolean, Integer, String, DateTime
 from flask import url_for
-from networkx.algorithms import breadth_first_search
 
 from ..db import Base
-from ..util.sqla import Enum34_ColumnType, MutableDict, JSONEncodedDict, ListOfStrings, MutableList
+from ..util.sqla import Enum34_ColumnType, MutableDict, JSONEncodedDict
 from .. import TaskStatus, StageStatus, signal_task_status_change
 from ..util.helpers import wait_for_file
 import datetime

--- a/cosmos/models/Task.py
+++ b/cosmos/models/Task.py
@@ -155,6 +155,7 @@ class Task(Base):
     # output_dir = Column(String(255))
     _status = Column(Enum34_ColumnType(TaskStatus), default=TaskStatus.no_attempt, nullable=False)
     successful = Column(Boolean, nullable=False)
+    scheduling_error = Column(Boolean, default=False, nullable=False)
     started_on = Column(DateTime)  # FIXME this should probably be deleted.  Too hard to determine.
     submitted_on = Column(DateTime)
     finished_on = Column(DateTime)

--- a/cosmos/models/Task.py
+++ b/cosmos/models/Task.py
@@ -74,7 +74,7 @@ def task_status_changed(task):
             # (b) give transient gremlins time to hopefully resolve themselves.
             #
             timeout = 5 * (random.random() + 1)
-            task.log.warn('%s attempt #%s failed to schedule, will retry in %.1f sec',
+            task.log.warn('%s attempt #%s failed to schedule, will pause for %.1f sec',
                           task, task.attempt, timeout)
             sleep_through_signals(timeout)
             task.scheduling_error = False

--- a/cosmos/models/Task.py
+++ b/cosmos/models/Task.py
@@ -155,7 +155,7 @@ class Task(Base):
     # output_dir = Column(String(255))
     _status = Column(Enum34_ColumnType(TaskStatus), default=TaskStatus.no_attempt, nullable=False)
     successful = Column(Boolean, nullable=False)
-    scheduling_error = Column(Boolean, default=False, nullable=False)
+    scheduling_error = Column(Boolean, nullable=False)
     started_on = Column(DateTime)  # FIXME this should probably be deleted.  Too hard to determine.
     submitted_on = Column(DateTime)
     finished_on = Column(DateTime)

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -523,7 +523,6 @@ def _process_finished_tasks(jobmanager):
     for task in jobmanager.get_finished_tasks():
         if task.NOOP or task.exit_status == 0:
             task.status = TaskStatus.successful
-            yield task
         elif task.scheduling_error:
             #
             # Wait 5-10 sec before retrying to
@@ -537,7 +536,8 @@ def _process_finished_tasks(jobmanager):
             task.status = TaskStatus.no_attempt
         else:
             task.status = TaskStatus.failed
-            yield task
+
+        yield task
 
 
 def handle_exits(workflow, do_atexit=True):

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -5,7 +5,6 @@ Tools for defining, running and terminating Cosmos workflows.
 import atexit
 import datetime
 import os
-import random
 import re
 import sys
 import time
@@ -25,7 +24,6 @@ from networkx.algorithms.dag import descendants, topological_sort
 
 from ..util.iterstuff import only_one
 from ..util.helpers import duplicates, get_logger, mkdir
-from ..util.signal_handlers import sleep_through_signals
 from ..util.sqla import Enum34_ColumnType, MutableDict, JSONEncodedDict
 from ..db import Base
 from ..core.cmd_fxn import signature
@@ -530,17 +528,6 @@ def _process_finished_tasks(jobmanager):
     for task in jobmanager.get_finished_tasks():
         if task.NOOP or task.exit_status == 0:
             task.status = TaskStatus.successful
-        elif task.scheduling_error:
-            #
-            # Wait 5-10 sec before retrying to
-            # (a) avoid kicking the scheduler when it's having trouble, and
-            # (b) give transient gremlins time to hopefully resolve themselves.
-            #
-            timeout = 5 * (random.random() + 1)
-            task.log.warn('%s failed to schedule, will retry in %.1f sec', task, timeout)
-            sleep_through_signals(timeout)
-            task.scheduling_error = False
-            task.status = TaskStatus.no_attempt
         else:
             task.status = TaskStatus.failed
 

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -33,6 +33,11 @@ from ..core.cmd_fxn import signature
 from .. import TaskStatus, StageStatus, WorkflowStatus, signal_workflow_status_change
 from .Task import Task
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
 opj = os.path.join
 
 
@@ -116,6 +121,7 @@ class Workflow(Base):
         self.dont_garbage_collect = []
 
     @property
+    @lru_cache()
     def log(self):
         return get_logger('cosmos-%s' % self.name, (self.primary_log_path or 'workflow.log'))
 

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -117,7 +117,7 @@ class Workflow(Base):
 
     @property
     def log(self):
-        return get_logger('cosmos-%s' % Workflow.name, (self.primary_log_path or 'workflow.log'))
+        return get_logger('cosmos-%s' % self.name, (self.primary_log_path or 'workflow.log'))
 
     def make_output_dirs(self):
         dirs = {os.path.dirname(p) for t in self.tasks for p in t.output_map.values() if p is not None}

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -240,6 +240,7 @@ class Workflow(Base):
                         mem_req=params_or_signature_default_or('mem_req', None),
                         time_req=time_req,
                         successful=False,
+                        scheduling_error=False,
                         attempt=1,
                         NOOP=False
                         )

--- a/cosmos/util/sqla.py
+++ b/cosmos/util/sqla.py
@@ -1,6 +1,10 @@
+import json
+import six
+
 import sqlalchemy.types as types
 from sqlalchemy.ext.mutable import Mutable
-import six
+from sqlalchemy.types import TypeDecorator
+
 
 class Enum34_ColumnType(types.TypeDecorator):
     """
@@ -55,11 +59,6 @@ def get_or_create(session, model, **kwargs):
         instance = model(**kwargs)
         # session.add(instance)
         return instance, True
-
-
-from sqlalchemy.types import TypeDecorator, VARCHAR
-import json
-
 
 class JSONEncodedDict(TypeDecorator):
     "Represents an immutable structure as a json-encoded string."

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ def find_all(path, reg_expr, inverse=False, remove_prefix=False):
 
 install_requires = [
     "backports.functools-lru-cache",
+    "black_magic>=0.0.10",  # to get a signature preserving partial() in cosmos.api
     "decorator",
     "flask",
     'funcsigs',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ def find_all(path, reg_expr, inverse=False, remove_prefix=False):
 
 
 install_requires = [
+    "backports.functools-lru-cache",
     "decorator",
     "flask",
     'funcsigs',


### PR DESCRIPTION
1. Add a new `Task.scheduling_error` field.
2. Set this field if `qacct` shows the errors we've been seeing this past week.
3. If/when `_process_finished_tasks()` sees this flag,
    a. immediately log a warning error,
    b. wait 5–10 sec,
    c. clear the flag, then
    d. set the Task's status to `no_attempt` so it gets retried.
4. Use "suspicious" instead of "corrupt" to describe unexpected `qacct` output.
