### PR TITLE
more ops help

### DIFF
--- a/cosmos/job/drm/drm_local.py
+++ b/cosmos/job/drm/drm_local.py
@@ -69,37 +69,45 @@ class DRM_Local(DRM):
                     wall_time=time.time() - self.procs[task.drm_jobID].start_time)
 
     def _signal(self, task, sig):
-        """Send a signal to a local task and any child (background or pipe) processes."""
+        """Send the signal to a task and its child (background or pipe) processes."""
         try:
             pgid = os.getpgid(int(task.drm_jobID))
             os.kill(int(task.drm_jobID), sig)
             task.log.info("%s sent signal %s to pid %s" % (task, sig, task.drm_jobID))
             os.killpg(pgid, sig)
-            task.log.info("%s sent signal %s to pgid %s" % (task, pgid, task.drm_jobID))
+            task.log.info("%s sent signal %s to pgid %s" % (task, sig, pgid))
         except OSError:
             pass
 
-    def interrupt(self, task):
-        """Terminate a task using SIGINT."""
-        self._signal(task, signal.SIGINT)
-
-    def terminate(self, task):
-        """Terminate a task using SIGTERM."""
-        self._signal(task, signal.SIGTERM)
-
-    def kill(self, task):
-        """Kill a task using SIGKILL."""
-        self._signal(task, signal.SIGKILL)
+    @staticmethod
+    def is_running_locally(task):
+        """Return true if a task is running locally."""
+        try:
+            proc = psutil.Process(int(task.drm_jobID))
+            return proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE
+        except psutil.NoSuchProcess:
+            return False
 
     def kill_tasks(self, tasks):
+        """
+        Progressively send stronger kill signals to the specified tasks.
+        """
+        for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGKILL):
+            signal_sent = False
+            for t in tasks:
+                if self.is_running_locally(t):
+                    self._signal(t, sig)
+                    signal_sent = True
+
+            if not signal_sent:
+                break
+            sleep_through_signals(10)
+
         for t in tasks:
-            self.interrupt(t)
-        sleep_through_signals(10)
-        for t in tasks:
-            self.terminate(t)
-        sleep_through_signals(10)
-        for t in tasks:
-            self.kill(t)
+            if self.is_running_locally(t):
+                t.log.warning("%s is still running locally!", t)
+            else:
+                t.log.info("%s has exited", t)
 
 
 class JobStatusError(Exception):

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -457,6 +457,26 @@ class Workflow(Base):
                 return t
         return None
 
+    def get_exit_code(self):
+        """
+        Return an integer callers can use as a POSIX exit code.
+        """
+        if self.successful:
+            return 0
+
+        # if killed by a signal, return the signal number that did us in
+        if self.termination_signal:
+            return self.termination_signal
+
+        # return the exit code of the first failed job that provided one
+        ft = self.get_first_failed_task()
+        if ft is not None:
+            return ft.exit_status
+
+        self.log.warning("%s unable to pinpoint cause of failure, returning %d",
+                         self, os.EX_SOFTWARE)
+        return os.EX_SOFTWARE
+
 
 # @event.listens_for(Workflow, 'before_delete')
 # def before_delete(mapper, connection, target):

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -34,6 +34,8 @@ from .Task import Task
 
 opj = os.path.join
 
+DISTANT_FUTURE = datetime.datetime(datetime.MAXYEAR, 12, 31)
+
 
 def default_task_log_output_dir(task, subdir=''):
     """The default function for computing Task.log_output_dir"""
@@ -446,7 +448,7 @@ class Workflow(Base):
         self.session.commit()
         print >> sys.stderr, '%s Deleted' % self
 
-    def get_first_failed_task(self, key=lambda t: t.finished_on):
+    def get_first_failed_task(self, key=lambda t: t.finished_on or DISTANT_FUTURE):
         """
         Return the first failed Task (chronologically).
 
@@ -478,7 +480,7 @@ def _run(workflow, session, task_queue):
             if task.status == TaskStatus.failed and task.must_succeed:
 
                 if workflow.info['fail_fast']:
-                    workflow.log.info('Exiting run loop at first Task failure')
+                    workflow.log.info('%s Exiting run loop at first Task failure: %s, error %s', workflow, task, task.exit_status)
                     workflow.terminate(due_to_failure=True)
                     return
 

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -34,8 +34,6 @@ from .Task import Task
 
 opj = os.path.join
 
-DISTANT_FUTURE = datetime.datetime(datetime.MAXYEAR, 12, 31)
-
 
 def default_task_log_output_dir(task, subdir=''):
     """The default function for computing Task.log_output_dir"""
@@ -448,13 +446,13 @@ class Workflow(Base):
         self.session.commit()
         print >> sys.stderr, '%s Deleted' % self
 
-    def get_first_failed_task(self, key=lambda t: t.finished_on or DISTANT_FUTURE):
+    def get_first_failed_task(self, key=lambda t: t.finished_on):
         """
         Return the first failed Task (chronologically).
 
         If no Task failed, return None.
         """
-        for t in sorted(self.task_graph(), key=key):
+        for t in sorted([t for t in self.tasks if key(t) is not None], key=key):
             if t.exit_status:
                 return t
         return None

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -446,17 +446,15 @@ class Workflow(Base):
         self.session.commit()
         print >> sys.stderr, '%s Deleted' % self
 
-    def exit_status(self):
+    def get_first_failed_task(self, key=lambda t: t.finished_on):
         """
-        Return the exit status of the first failed Task (topologically, not chronologically).
+        Return the first failed Task (chronologically).
 
         If no Task failed, return None.
         """
-        for t in self.task_graph():
+        for t in sorted(self.task_graph(), key=key):
             if t.exit_status:
-                self.log.warning("%s took exit status %s from %s (%s)",
-                                 self, t.exit_status, t, t.status)
-                return t.exit_status
+                return t
         return None
 
 

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -457,26 +457,6 @@ class Workflow(Base):
                 return t
         return None
 
-    def get_exit_code(self):
-        """
-        Return an integer callers can use as a POSIX exit code.
-        """
-        if self.successful:
-            return 0
-
-        # if killed by a signal, return the signal number that did us in
-        if self.termination_signal:
-            return self.termination_signal
-
-        # return the exit code of the first failed job that provided one
-        ft = self.get_first_failed_task()
-        if ft is not None:
-            return ft.exit_status
-
-        self.log.warning("%s unable to pinpoint cause of failure, returning %d",
-                         self, os.EX_SOFTWARE)
-        return os.EX_SOFTWARE
-
 
 # @event.listens_for(Workflow, 'before_delete')
 # def before_delete(mapper, connection, target):

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -353,6 +353,8 @@ class Workflow(Base):
             return_code = None
             for ft in failed_tasks:
                 if ft.exit_status:
+                    self.log.warning("%s inheriting exit code %d from first failed task %s",
+                                     self, ft.exit_status, ft)
                     return_code = ft.exit_status
                     break
 
@@ -371,7 +373,7 @@ class Workflow(Base):
                 session.commit()
                 return 0
             else:
-                self.log.warning('Workflow exited with status %s', self.status)
+                self.log.warning('%s exited with status "%s"', self, self.status)
                 session.commit()
                 return return_code or None
         else:

--- a/cosmos/util/helpers.py
+++ b/cosmos/util/helpers.py
@@ -199,3 +199,23 @@ def get_logger(name, path=None):
 
     return log
 
+
+def derive_exit_code_from_workflow(workflow):
+    """
+    Return an integer suitable for use as a CLI script's exit code.
+    """
+    if workflow.successful:
+        return 0
+
+    # if killed by a signal, return the signal number that terminated the workflow
+    if workflow.termination_signal:
+        return workflow.termination_signal
+
+    # otherwise return the exit code of the first failed job that provided one
+    ft = workflow.get_first_failed_task()
+    if ft is not None:
+        return ft.exit_status
+
+    workflow.log.warning("%s unable to pinpoint cause of failure, returning %d",
+                         workflow, os.EX_SOFTWARE)
+    return os.EX_SOFTWARE

--- a/cosmos/util/signal_handlers.py
+++ b/cosmos/util/signal_handlers.py
@@ -157,7 +157,7 @@ class SGESignalHandler(object):
         self._logging_event.set()
 
         if signum in self.lethal_signals:
-            self.workflow.terminate_when_safe = True
+            self.workflow.termination_signal = signum
 
     def _cache_existing_handler(self, sig):
         prev_handler = signal.getsignal(sig)
@@ -196,8 +196,8 @@ class SGESignalHandler(object):
                 self._log_signal_receipt(new_signals)
                 self._signals_logged += new_signals
 
-                if self.workflow.terminate_when_safe:
-                    self._log.info('%s Early-termination flag has been set',
-                                   self._workflow_name)
+                if self.workflow.termination_signal:
+                    self._log.info('%s Early-termination flag (%d) has been set',
+                                   self._workflow_name, self.workflow.termination_signal)
                 else:
                     self._log.debug('%s Ignoring benign signal(s)', self._workflow_name)


### PR DESCRIPTION
Instead of returning `True` when a workflow succeeds and `False` when it doesn't, return `0` on success and the error code from the first failed Task when it doesn't. (Or `None`, if `dry` is set or an error code can't be determined).

This change requires changes to PIPE and to other callers that inspect the return code from `workflow.run()`. I suppose an alternative would be to add a new field on Workflow, maintain the Boolean return code, and callers who cared about the specific reason could inspect `workflow.task_error_codes` or something like that. This seems a little easier at the cost of some inconvenience to existing callers. But let me know what you think.