### PR TITLE
Don't use the tempfile module in drm_ge

### DIFF
--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -218,7 +218,7 @@ def _qacct_raw(task, timeout=600, quantum=15):
             qacct_stderr_str = None
             qacct_returncode = err.returncode
 
-        if re.match(r'error: job id \d+ not found', qacct_stderr_str):
+        if qacct_stderr_str and re.match(r'error: job id \d+ not found', qacct_stderr_str):
             if i > 0:
                 task.workflow.log.info('%s SGE (qacct -j %s) reports "not found"; this may mean '
                                        'qacct is merely slow, or %s died in the \'qw\' state',

--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -4,7 +4,8 @@ import re
 import os
 from collections import OrderedDict
 import time
-from .util import check_output_and_stderr, convert_size_to_kb, div, exit_process_group
+from .util import CosmosCalledProcessError, check_output_and_stderr, \
+                  convert_size_to_kb, div, exit_process_group
 from ... import TaskStatus
 from ...util.signal_handlers import sleep_through_signals
 
@@ -213,9 +214,9 @@ def _qacct_raw(task, timeout=600, quantum=15):
                 preexec_fn=exit_process_group)
             if qacct_stdout_str.strip():
                 break
-        except sp.CalledProcessError as err:
+        except CosmosCalledProcessError as err:
             qacct_stdout_str = err.output.strip()
-            qacct_stderr_str = None
+            qacct_stderr_str = err.stderr.strip()
             qacct_returncode = err.returncode
 
         if qacct_stderr_str and re.match(r'error: job id \d+ not found', qacct_stderr_str):

--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -53,7 +53,7 @@ class DRM_GE(DRM):
         This method will only yield corrupt qacct data if every outstanding task
         has been affected by this SGE bug.
         """
-        if len(tasks):
+        if tasks:
             qjobs = _qstat_all()
             corrupt_data = {}
 
@@ -93,7 +93,7 @@ class DRM_GE(DRM):
         :param tasks: tasks that have been submitted to the job manager
         :returns: (dict) task.drm_jobID -> drm_status
         """
-        if len(tasks):
+        if tasks:
             qjobs = _qstat_all()
 
             def f(task):
@@ -124,7 +124,7 @@ class DRM_GE(DRM):
                                     json.dumps(d, indent=4, sort_keys=True)))
 
         processed_data = dict(
-            exit_status=int(d['exit_status']) if not job_failed else int(re.search('^(\d+)', d['failed']).group(1)),
+            exit_status=int(d['exit_status']) if not job_failed else int(re.search(r'^(\d+)', d['failed']).group(1)),
 
             percent_cpu=div(float(d['cpu']), float(d['ru_wallclock'])),
             wall_time=float(d['ru_wallclock']),
@@ -159,7 +159,7 @@ class DRM_GE(DRM):
         return processed_data, data_are_corrupt
 
     def kill(self, task):
-        "Terminates a task"
+        """Terminate a task"""
         raise NotImplementedError
 
     def kill_tasks(self, tasks):
@@ -281,11 +281,9 @@ def _qstat_all():
         lines = sp.check_output(['qstat'], preexec_fn=exit_process_group).strip().split('\n')
     except (sp.CalledProcessError, OSError):
         return {}
-    keys = re.split("\s+", lines[0])
+    keys = re.split(r"\s+", lines[0])
     bjobs = {}
     for l in lines[2:]:
-        items = re.split("\s+", l.strip())
+        items = re.split(r"\s+", l.strip())
         bjobs[items[0]] = dict(zip(keys, items))
     return bjobs
-
-

--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -160,7 +160,7 @@ class DRM_GE(DRM):
         return processed_data, data_are_corrupt
 
     def kill(self, task):
-        """Terminate a task"""
+        """Terminate a task."""
         raise NotImplementedError
 
     def kill_tasks(self, tasks):

--- a/cosmos/job/drm/drm_slurm.py
+++ b/cosmos/job/drm/drm_slurm.py
@@ -30,7 +30,7 @@ class DRM_SLURM(DRM):
 
         try:
             out = sp.check_output(sub, env=os.environ, preexec_fn=exit_process_group, shell=True)
-            task.drm_jobID = unicode(re.search('job (\d+)', out).group(1))
+            task.drm_jobID = unicode(re.search(r'job (\d+)', out).group(1))
         except sp.CalledProcessError as cpe:
             task.log.error('%s submission to %s failed with error %s: %s' %
                            (task, task.drm, cpe.returncode, cpe.output.strip()))
@@ -41,12 +41,11 @@ class DRM_SLURM(DRM):
         else:
             task.status = TaskStatus.submitted
 
-
     def filter_is_done(self, tasks):
         """
         Yield a dictionary of Slurm job metadata for each task that has completed.
         """
-        if len(tasks):
+        if tasks:
             qjobs = _qstat_all()
 
         for task in tasks:
@@ -58,20 +57,19 @@ class DRM_SLURM(DRM):
                 data['exit_status'] = (0 if data['exit_status'] is None else data['exit_status'])
                 yield task, data
             elif any(finished_state in qjobs[jid]['STATE'] for finished_state in
-                   ['BOOT_FAIL', 'CANCELLED', 'FAILED', 'NODE_FAIL', 'PREEMPTED', 'REVOKED', 'TIMEOUT']):
+                     ['BOOT_FAIL', 'CANCELLED', 'FAILED', 'NODE_FAIL', 'PREEMPTED', 'REVOKED', 'TIMEOUT']):
                 # If the job is tagged with any of the "failure" exit codes, it has completed with exit code > 0
                 data = self._get_task_return_data(task)
                 data['exit_status'] = (1 if (data['exit_status'] is None or data['exit_status'] == 0)
                                        else data['exit_status'])
                 yield task, data
 
-
     def drm_statuses(self, tasks):
         """
         :param tasks: tasks that have been submitted to the job manager
         :returns: (dict) task.drm_jobID -> drm_status
         """
-        if len(tasks):
+        if tasks:
             qjobs = _qstat_all()
 
             def f(task):
@@ -80,7 +78,6 @@ class DRM_SLURM(DRM):
             return {task.drm_jobID: f(task) for task in tasks}
         else:
             return {}
-
 
     def _get_task_return_data(self, task):
         """
@@ -104,11 +101,9 @@ class DRM_SLURM(DRM):
         task.workflow.log.info("%s returned with exit code: '%s'" % (task, str(exit_code)))
         return d
 
-
     def kill(self, task):
-        "Terminates a task"
+        """Terminate a task."""
         raise NotImplementedError
-
 
     def kill_tasks(self, tasks):
         for group in grouper(50, tasks):
@@ -191,11 +186,9 @@ def _qstat_all():
         lines = sp.check_output(['squeue', '-l'], preexec_fn=exit_process_group).strip().split('\n')
     except (sp.CalledProcessError, OSError):
         return {}
-    keys = re.split("\s+", lines[1].strip())
+    keys = re.split(r"\s+", lines[1].strip())
     bjobs = {}
     for l in lines[2:]:
-        items = re.split("\s+", l.strip())
+        items = re.split(r"\s+", l.strip())
         bjobs[items[0]] = dict(zip(keys, items))
     return bjobs
-
-

--- a/cosmos/job/drm/util.py
+++ b/cosmos/job/drm/util.py
@@ -7,7 +7,7 @@ class CosmosCalledProcessError(subprocess.CalledProcessError):
     Just like CalledProcessError, but includes stderr.
     """
     def __init__(self, returncode, cmd, output=None, stderr=None):
-        super(CosmosCalledProcessError, self).__init__(self, returncode, cmd, output)
+        super(CosmosCalledProcessError, self).__init__(returncode, cmd, output)
         self.stderr = stderr
 
 

--- a/cosmos/job/drm/util.py
+++ b/cosmos/job/drm/util.py
@@ -1,4 +1,31 @@
 import os
+import subprocess
+
+
+def check_output_and_stderr(*popenargs, **kwargs):
+    """
+    Run command with arguments and return its stdout and stderr as byte strings.
+
+    Lifted from the subprocess.check_output() implementation, to which it is
+    identical, save that it returns a (stdout, stderr) tuple as opposed to
+    simply stdout.
+
+    Note that the CalledProcessError object raised by this method does not
+    contain any stderr -- same (confusing) behavior as subprocess.check_output().
+    """
+    if 'stdout' in kwargs:
+        raise ValueError('stdout argument not allowed, it will be overridden.')
+    if 'stderr' in kwargs:
+        raise ValueError('stderr argument not allowed, it will be overridden.')
+    process = subprocess.Popen(stdout=subprocess.PIPE, stderr=subprocess.PIPE, *popenargs, **kwargs)
+    output, stderr = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        raise subprocess.CalledProcessError(retcode, cmd, output=output)
+    return output, stderr
 
 
 def convert_size_to_kb(size_str):

--- a/cosmos/job/drm/util.py
+++ b/cosmos/job/drm/util.py
@@ -2,6 +2,15 @@ import os
 import subprocess
 
 
+class CosmosCalledProcessError(subprocess.CalledProcessError):
+    """
+    Just like CalledProcessError, but includes stderr.
+    """
+    def __init__(self, returncode, cmd, output=None, stderr=None):
+        super(CosmosCalledProcessError, self).__init__(self, returncode, cmd, output)
+        self.stderr = stderr
+
+
 def check_output_and_stderr(*popenargs, **kwargs):
     """
     Run command with arguments and return its stdout and stderr as byte strings.
@@ -24,7 +33,7 @@ def check_output_and_stderr(*popenargs, **kwargs):
         cmd = kwargs.get("args")
         if cmd is None:
             cmd = popenargs[0]
-        raise subprocess.CalledProcessError(retcode, cmd, output=output)
+        raise CosmosCalledProcessError(retcode, cmd, output=output, stderr=stderr)
     return output, stderr
 
 


### PR DESCRIPTION
Turns out subprocess.check_output() is almost exactly what we need here, except that it drops stderr on the floor. I copied its implementation and added stderr support to CalledProcessError to make our use case run more smoothly. No more file i/o.

If this looks good I'll apply the same fixes to drm_slurm.