### PR TITLE
Defend against SGE's weird response to network failure

### DIFF
--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -188,11 +188,11 @@ def _is_corrupt(qacct_dict):
     Note that qacct may return a date that precedes the Epoch (!), depending on
     the $TZ env. variable. To be safe we check for dates within 24 hours of it.
     """
-    return \
-        qacct_dict.get('qsub_time', '').startswith('12/31/1969') or \
-        qacct_dict.get('qsub_time', '').startswith('01/01/1970') or \
-        qacct_dict.get('start_time', None) == '-/-' or \
-        qacct_dict.get('end_time', None) == '-/-'
+    return (qacct_dict.get('qsub_time', '').startswith('12/31/1969') or \
+            qacct_dict.get('qsub_time', '').startswith('01/01/1970') or \
+            qacct_dict.get('start_time', None) == '-/-' or \
+            qacct_dict.get('end_time', None) == '-/-') and \
+           ("before writing exit_status" not in qacct_dict.get('failed', ''))
 
 
 def _qacct_raw(task, timeout=600, quantum=15):
@@ -290,5 +290,3 @@ def _qstat_all():
         items = re.split(r"\s+", l.strip())
         bjobs[items[0]] = dict(zip(keys, items))
     return bjobs
-
-

--- a/cosmos/job/drm/drm_ge.py
+++ b/cosmos/job/drm/drm_ge.py
@@ -188,9 +188,9 @@ def _is_corrupt(qacct_dict):
     Note that qacct may return a date that precedes the Epoch (!), depending on
     the $TZ env. variable. To be safe we check for dates within 24 hours of it.
     """
-    return (qacct_dict.get('qsub_time', '').startswith('12/31/1969') or \
-            qacct_dict.get('qsub_time', '').startswith('01/01/1970') or \
-            qacct_dict.get('start_time', None) == '-/-' or \
+    return (qacct_dict.get('qsub_time', '').startswith('12/31/1969') or
+            qacct_dict.get('qsub_time', '').startswith('01/01/1970') or
+            qacct_dict.get('start_time', None) == '-/-' or
             qacct_dict.get('end_time', None) == '-/-') and \
            ("before writing exit_status" not in qacct_dict.get('failed', ''))
 


### PR DESCRIPTION
This PR amends the `_is_corrupt()` method so that if SGE reports "failed": "19 : before writing exit_status" we give up on the job, even if the timestamps are totally out of whack. We see "before writing exit_status" in SGE output when the shepherd on the remote node is totally unavailable (like, for example, if a breaker trips and takes the whole host down).

As far as I can tell, when the shepherd dies, the error is totally unrecoverable, SGE will never find the job again. Cosmos should recognize the job as totally dead when this happens.