### PR TITLE
Fix `stage_delete` to not throw an exception

### DIFF
--- a/cosmos/web/views.py
+++ b/cosmos/web/views.py
@@ -11,7 +11,7 @@ from ..graph.draw import draw_task_graph, draw_stage_graph
 
 
 def gen_bprint(session):
-    
+
     def get_workflow(id):
         return session.query(Workflow).filter_by(id=id).one()
 
@@ -68,7 +68,7 @@ def gen_bprint(session):
         s = session.query(Stage).filter(Stage.workflow_id == ex_id, Stage.name == stage_name).one()
         flash('Deleted %s' % s)
         ex_url = s.workflow.url
-        s.delete(delete_files=False, descendants=delete_descendants)
+        s.delete(descendants=delete_descendants)
         return redirect(ex_url)
 
     # @bprint.route('/task/<int:id>/')


### PR DESCRIPTION
Looks like `stage_delete` passes a stale parameter to `session.delete`. I couldn't delete a failed cosmos stage without this fix in v. 2.5.3. This patches the latest bits with the fix.