### PR TITLE
All else being equal, schedule tasks in the order added to the DAG.

### DIFF
--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -543,13 +543,13 @@ def _run_queued_and_ready_tasks(task_queue, workflow):
                    degree == 0 and task.status == TaskStatus.no_attempt]
 
     if max_cores is None:
-        submittable_tasks = ready_tasks
+        submittable_tasks = sorted(ready_tasks, key=lambda t: t.id)
     else:
         cores_used = sum([t.core_req for t in workflow.jobmanager.running_tasks])
         cores_left = max_cores - cores_used
 
         submittable_tasks = []
-        ready_tasks = sorted(ready_tasks, key=lambda t: t.core_req)
+        ready_tasks = sorted(ready_tasks, key=lambda t: (t.core_req, t.id))
         while len(ready_tasks) > 0:
             task = ready_tasks[0]
             there_are_cores_left = task.core_req <= cores_left


### PR DESCRIPTION
A few of our cosmos workflows parallelize lazily: chromosome 1 goes in one sub-task, chrom 2 in another, etc. The current cosmos implementation ignores the order in which tasks are added to the dag when scheduling new ones. This PR prefers, all else being equal, tasks that were added earlier. (In our case, longer chromosomes.)