### PR TITLE
relax type checks

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -47,17 +47,17 @@ def recursive_resolve_dependency(parameter):
     """
     if isinstance(parameter, Dependency):
         return parameter.resolve(), {parameter.task}
-    elif type(parameter) in (bool, float, int, long, str, unicode, types.NoneType):
+    elif any(isinstance(parameter, t) for t in (bool, float, int, long, str, unicode, types.NoneType)):
         return parameter, set()
-    elif type(parameter) == list:
+    elif isinstance(parameter, list):
         tuple_list = list(recursive_resolve_dependency(v) for v in parameter)
         return list(rds for (rds, _) in tuple_list), set.union(*[tasks for _, tasks in tuple_list]) if len(
             tuple_list) else set()
-    elif type(parameter) == tuple:
+    elif isinstance(parameter, tuple):
         tuple_tuple = tuple(recursive_resolve_dependency(v) for v in parameter)
         return tuple(rds for (rds, _) in tuple_tuple), set.union(*[tasks for _, tasks in tuple_tuple]) if len(
             tuple_tuple) else set()
-    elif type(parameter) == dict:
+    elif isinstance(parameter, dict):
         tuple_dict = {k: recursive_resolve_dependency(v) for k, v in parameter.iteritems()}
         return ({k: rds for k, (rds, _) in tuple_dict.iteritems()},
                 set.union(*[tasks for _, tasks in tuple_dict.itervalues()]) if len(tuple_dict) else set())


### PR DESCRIPTION
this was preventing the use of OrderedDicts w/ the JSON parser (a la `json.load(fp, object_pairs_hook=OrderedDict)`)